### PR TITLE
docs: add git workflow conventions and contributing guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,64 +1,25 @@
-<!--
-  Before opening this PR, confirm:
-  - Title follows convention: type(scope): description
-  - You've self-reviewed the diff
-  - `pnpm validate` passes
-  - Target ≤400 LOC (justify if larger)
--->
-
 ## Why
 
-<!--
-  What problem does this solve? What's the motivation?
-  Link to the issue. This is the most important section —
-  reviewers evaluate your APPROACH, not just your code.
--->
+<!-- What motivated this change? What problem, idea, or need drove it?
+     This is for future-you — you WILL forget in 3 months. -->
 
-Closes #
+## What Changed
 
-## What
+<!-- Brief narrative of what you did. Not a diff summary —
+     explain the approach and any key decisions. -->
 
-<!--
-  Summarize the changes. Bullet list.
-  Give reviewers a map of the diff before they open it.
--->
+## Learnings
 
--
--
+<!-- Capture knowledge from this work for future reference.
+     This section feeds back into AGENTS.md, skills, and orchestration docs.
 
-## How to Test
+     Prompts to consider:
+     - What was tricky, unexpected, or got you stuck?
+     - How did you resolve it? What did you discover?
+     - Any patterns, gotchas, or edge cases worth remembering?
+     - Should anything here become a rule in AGENTS.md?
+     - Did you find a gap in existing docs/skills/tooling? -->
 
-<!--
-  Exact steps to verify this works. Be specific enough that
-  a reviewer can reproduce without asking questions.
--->
+---
 
-1.
-2.
-3.
-
-## Screenshots
-
-<!--
-  Required for UI changes. Before/after preferred.
-  Omit this section entirely if no visual changes.
--->
-
-## Notes for Reviewer
-
-<!--
-  Optional. Call out:
-  - Areas of uncertainty where you want focused feedback
-  - Tradeoffs you made and why
-  - Things you explicitly decided NOT to do
-  - Known limitations or follow-up work planned
--->
-
-## Checklist
-
-- [ ] `pnpm validate` passes (type-check + lint + tests)
-- [ ] Tests added/updated for new behavior
-- [ ] No `any`, `@ts-ignore`, or `console.log` left in
-- [ ] Mobile tested (if UI change)
-- [ ] Docs updated (if public API changed)
-- [ ] Breaking changes noted in PR title with `!` and described above
+- [ ] CI passes (`pnpm validate`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,68 +1,64 @@
-## Summary
+<!--
+  Before opening this PR, confirm:
+  - Title follows convention: type(scope): description
+  - You've self-reviewed the diff
+  - `pnpm validate` passes
+  - Target ≤400 LOC (justify if larger)
+-->
 
-<!-- Brief description of the changes in this PR -->
-<!-- What problem does this solve? What feature does it add? -->
+## Why
 
-## Type
-
-<!-- Select the type of change -->
-
-- [ ] Feature (new functionality)
-- [ ] Fix (bug fix)
-- [ ] Chore (maintenance, docs, tooling, dependencies)
-
-## Changes
-
-<!-- List the specific changes made -->
-
-- Change 1
-- Change 2
-- Change 3
-
-## Testing
-
-<!-- Verify that all tests pass locally before submitting -->
-
-- [ ] Unit tests pass (`pnpm test:run`)
-- [ ] E2E tests pass (`pnpm test:e2e`)
-- [ ] Type check passes (`pnpm type-check`)
-- [ ] Lint passes (`pnpm lint`)
-- [ ] Build succeeds (`pnpm build`)
-
-## Testing Details
-
-<!-- Describe how you tested these changes -->
-<!-- Include steps to reproduce if applicable -->
-
-## Breaking Changes
-
-<!-- Does this PR introduce breaking changes? -->
-
-- [ ] This PR includes breaking changes
-
-<!-- If breaking changes, describe the migration path and impact -->
-
-## Related Issues
-
-<!-- Link related issues using #issue-number -->
+<!--
+  What problem does this solve? What's the motivation?
+  Link to the issue. This is the most important section —
+  reviewers evaluate your APPROACH, not just your code.
+-->
 
 Closes #
 
+## What
+
+<!--
+  Summarize the changes. Bullet list.
+  Give reviewers a map of the diff before they open it.
+-->
+
+-
+-
+
+## How to Test
+
+<!--
+  Exact steps to verify this works. Be specific enough that
+  a reviewer can reproduce without asking questions.
+-->
+
+1.
+2.
+3.
+
+## Screenshots
+
+<!--
+  Required for UI changes. Before/after preferred.
+  Omit this section entirely if no visual changes.
+-->
+
+## Notes for Reviewer
+
+<!--
+  Optional. Call out:
+  - Areas of uncertainty where you want focused feedback
+  - Tradeoffs you made and why
+  - Things you explicitly decided NOT to do
+  - Known limitations or follow-up work planned
+-->
+
 ## Checklist
 
-- [ ] Code follows the project's style guidelines
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests passed locally with my changes
-- [ ] Any dependent changes have been merged and published
-
-## Screenshots (if applicable)
-
-<!-- Add screenshots for UI changes -->
-
-## Additional Context
-
-<!-- Add any other context about the PR here -->
+- [ ] `pnpm validate` passes (type-check + lint + tests)
+- [ ] Tests added/updated for new behavior
+- [ ] No `any`, `@ts-ignore`, or `console.log` left in
+- [ ] Mobile tested (if UI change)
+- [ ] Docs updated (if public API changed)
+- [ ] Breaking changes noted in PR title with `!` and described above

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ AI Explanations: Cached indefinitely (SHA256 of inputs)
 - `'use client'` only when needed (hooks, events, browser APIs)
 - shadcn/ui in `components/ui/` - do not modify directly
 - `motion/react` library (not framer-motion)
-- Named exports only (no default exports)
+- Named exports for libraries/components (default exports only where framework-required: `page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`)
 - **Performance**: Use `next/dynamic` for lazy loading heavy client components (Builder, Optimizer) with `Skeleton` fallbacks.
 - **Animations**: Avoid `motion.div` in virtualized lists or LCP elements.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,35 @@ AI Explanations: Cached indefinitely (SHA256 of inputs)
 - Encapsulated logic: Custom hooks in `src/hooks/`
 - SSR safety: Check `typeof window !== 'undefined'`
 
+## GIT WORKFLOW
+
+Full conventions in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+### Branching
+- **`prod`** — Production (Fly.io deploys). Never commit directly.
+- **`dev`** — Integration branch. CI must pass. Never commit directly.
+- **Feature branches** — All work here. Branch from `dev`, merge back via PR.
+- **Naming**: `{type}/{kebab-case}` — e.g., `feat/draft-ui`, `fix/auth-redirect`, `chore/update-deps`
+- **Lifecycle**: Branch from `dev` → work → PR to `dev` (squash merge) → delete branch
+- **Promotion**: `dev` → `prod` via PR (merge commit) + semver tag
+
+### Commits
+- [Conventional Commits](https://www.conventionalcommits.org/) format: `type(scope): description`
+- **Types**: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `style`, `chore`, `revert`
+- **Scopes**: `draft`, `algorithms`, `monte-carlo`, `sleeper`, `auth`, `ui`, `api`, `db`, `trade`, `waivers`, `roster`, `players`, `animation`
+- Imperative mood, lowercase after colon, no trailing period, 72 char max
+- Body explains WHY not HOW. Footer: `Closes #N`, `BREAKING CHANGE:`
+
+### Pull Requests
+- Title matches commit convention: `type(scope): description`
+- Target ≤400 LOC changed. Over 800: split it.
+- Must include: Why, What, How to Test, Checklist
+- Template: `.github/PULL_REQUEST_TEMPLATE.md`
+
+### Merge Strategy
+- Feature branches → `dev`: **Squash merge**
+- `dev` → `prod`: **Merge commit** + semver tag
+
 ## ANTI-PATTERNS
 
 - **DO NOT** call Sleeper API from components - use `src/lib/sleeper/client.ts`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ Full conventions in [CONTRIBUTING.md](./CONTRIBUTING.md).
 - **Naming**: `{type}/{kebab-case}` — e.g., `feat/draft-ui`, `fix/auth-redirect`, `chore/update-deps`
 - **Lifecycle**: Branch from `dev` → work → PR to `dev` (squash merge) → delete branch
 - **Promotion**: `dev` → `prod` via PR (merge commit) + semver tag
+- **Trivial changes**: `docs:` and `chore:` single-file edits may go directly to `dev`
 
 ### Commits
 - [Conventional Commits](https://www.conventionalcommits.org/) format: `type(scope): description`
@@ -146,9 +147,14 @@ Full conventions in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ### Pull Requests
 - Title matches commit convention: `type(scope): description`
-- Target ≤400 LOC changed. Over 800: split it.
-- Must include: Why, What, How to Test, Checklist
+- One logical change per PR (not LOC-gated — keep it focused, not small)
+- PR description: **Why** (required), **What Changed** (narrative), **Learnings** (knowledge capture)
 - Template: `.github/PULL_REQUEST_TEMPLATE.md`
+
+### Learnings Feedback Loop
+- Every PR captures gotchas, stuck points, decisions, and gaps discovered during the work
+- After merge, review learnings and promote them to: AGENTS.md rules, skills, code comments, or ADRs
+- This is how individual PRs become institutional knowledge — do not skip it
 
 ### Merge Strategy
 - Feature branches → `dev`: **Squash merge**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Git workflow conventions (CONTRIBUTING.md, PR template, CHANGELOG)
+
+## [0.1.0] - 2026-02-04
+
+### Added
+- Initial project setup with Next.js 16 App Router
+- Sleeper API integration with rate limiting (16 req/sec)
+- VBD (Value Based Drafting) algorithm with full test coverage
+- Monte Carlo draft simulation engine
+- Supabase auth with Sleeper account connection
+- Draft assistant with real-time pick tracking
+- Trade analyzer with AI-powered explanations (Groq)
+- Waiver wire optimizer with FAAB support
+- Roster lineup optimizer
+- Balatro-inspired animation system
+- Mobile-first responsive layout
+- CI/CD pipeline (GitHub Actions + Fly.io)
+- Sentry error monitoring and performance tracing
+- PWA support with offline caching
+
+[Unreleased]: https://github.com/jdavini23/quantasy/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/jdavini23/quantasy/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Git workflow conventions (CONTRIBUTING.md, PR template, CHANGELOG)
+- Git workflow conventions (CONTRIBUTING.md, PR template, CHANGELOG, AGENTS.md)
 
 ## [0.1.0] - 2026-02-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,361 @@
+# Contributing to Quantasy
+
+## Quick Start
+
+```bash
+pnpm install
+cp .env.example .env.local
+pnpm db:start
+pnpm types:generate
+pnpm dev
+```
+
+---
+
+## Git Workflow
+
+### Branching Strategy — Modified GitHub Flow
+
+```
+prod ────────────●──────────────●──── (Fly.io deploys)
+                 ↑              ↑
+           (promote dev)  (promote dev)
+                 │              │
+dev  ──●──●──●──●──●──●──●──●──●──── (CI gate, always stable)
+       ↑     ↑        ↑     ↑
+  feat/A  fix/B   feat/C  chore/D
+```
+
+- **`prod`** — Production. Fly.io deploys from here. Never commit directly.
+- **`dev`** — Integration branch. CI must pass before anything merges. Never commit directly.
+- **Feature branches** — All work happens here. Short-lived (1-3 days max). Branch from `dev`.
+
+### Branch Naming
+
+**Pattern:** `{type}/{kebab-case-description}`
+
+| Type | Use for | Example |
+|------|---------|---------|
+| `feat/` | New features | `feat/draft-assistant-ui` |
+| `fix/` | Bug fixes | `fix/roster-sync-race-condition` |
+| `chore/` | Deps, config, tooling | `chore/upgrade-nextjs-16` |
+| `docs/` | Documentation only | `docs/algorithm-explainer` |
+| `refactor/` | Code restructuring (no behavior change) | `refactor/extract-sleeper-client` |
+| `ci/` | CI/CD pipeline changes | `ci/add-e2e-chromium-job` |
+| `perf/` | Performance improvements | `perf/player-list-virtualization` |
+| `test/` | Test-only changes | `test/vbd-edge-cases` |
+
+**Rules:**
+- Lowercase only, kebab-case, no spaces
+- Keep under 50 characters
+- Present tense (`add-dark-mode` not `added-dark-mode`)
+- No personal names (`john/fix-bug` is meaningless to future readers)
+
+### Branch Lifecycle
+
+```bash
+# 1. CREATE — always branch from latest dev
+git checkout dev && git pull
+git checkout -b feat/my-feature
+
+# 2. WORK — commit frequently with conventional messages
+git add src/components/DraftBoard.tsx
+git commit -m "feat(draft): add player card drag-and-drop"
+
+# 3. STAY CURRENT — rebase on dev before opening PR
+git fetch origin
+git rebase origin/dev
+
+# 4. PUSH & OPEN PR
+git push -u origin feat/my-feature
+gh pr create --base dev --title "feat(draft): add player card drag-and-drop"
+
+# 5. CI RUNS — type-check, lint, test, build must all pass
+
+# 6. MERGE — squash merge via GitHub UI
+
+# 7. DELETE BRANCH — GitHub auto-deletes after merge
+git checkout dev && git pull
+git branch -d feat/my-feature
+```
+
+### Merge Strategy
+
+| Merge Type | When | Why |
+|------------|------|-----|
+| **Squash merge** | Feature branches → `dev` | Keeps `dev` log clean; WIP commits disappear |
+| **Merge commit** | `dev` → `prod` promotions | Preserves the promotion event in history |
+
+### Promoting to Production
+
+```bash
+# Create a promotion PR
+gh pr create --base prod --head dev \
+  --title "chore: promote to prod [v1.x.0]" \
+  --body "## Changes since last promotion\n- feat: ...\n- fix: ..."
+
+# After merge, tag immediately
+git checkout prod && git pull
+git tag -a v1.x.0 -m "Release v1.x.0: Brief description"
+git push origin v1.x.0
+```
+
+---
+
+## Commit Messages
+
+Follow [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+### Format
+
+```
+<type>(<scope>): <imperative description>
+
+[optional body — explains WHY, not WHAT]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type | SemVer Impact | Use for |
+|------|--------------|---------|
+| `feat` | MINOR | New feature |
+| `fix` | PATCH | Bug fix |
+| `perf` | PATCH | Performance improvement (no API change) |
+| `refactor` | — | Code restructuring (no behavior change) |
+| `docs` | — | Documentation only |
+| `test` | — | Adding or correcting tests |
+| `build` | — | Build system, dependency changes |
+| `ci` | — | CI configuration changes |
+| `style` | — | Formatting, whitespace (no logic change) |
+| `chore` | — | Maintenance tasks |
+| `revert` | varies | Reverts a previous commit |
+
+### Scopes
+
+Match the project architecture:
+
+`draft` `algorithms` `monte-carlo` `sleeper` `auth` `ui` `api` `db` `trade` `waivers` `roster` `players` `animation`
+
+Scope is optional. Omit when the change is cross-cutting or doesn't fit a single module.
+
+### Subject Line Rules
+
+- **Imperative mood**: "add" not "added" or "adds"
+- **Lowercase** after the colon: `feat: add search` not `feat: Add search`
+- **No trailing period**
+- **72 character max** — hard limit
+- Must complete the sentence: *"If applied, this commit will ___"*
+
+### Body Rules
+
+- Separate from subject with a blank line
+- Wrap at 72 characters
+- Explain **why** the change was necessary, not **how** (the diff shows how)
+- Include context: what the previous behavior was and what it is now
+
+### Footer Conventions
+
+```
+Closes #123              — auto-closes issue on merge
+Fixes #456               — same as Closes
+Refs #789                — reference without closing
+BREAKING CHANGE: <desc>  — triggers MAJOR version bump
+Co-authored-by: Name <email>
+```
+
+### Breaking Changes
+
+Use `!` after the type AND/OR `BREAKING CHANGE:` in the footer:
+
+```
+feat(api)!: require auth header on all endpoints
+
+BREAKING CHANGE: Previously, GET /public/* was unauthenticated.
+All endpoints now require a valid Bearer token.
+```
+
+### Examples
+
+```bash
+# Minimal
+fix: correct off-by-one in pagination
+
+# With scope
+feat(draft): add snake-draft order visualization
+
+# With body
+perf(algorithms): cache VBD results with SHA256 key
+
+Previously, VBD recalculated on every page load even when inputs
+hadn't changed. This adds content-addressed caching with a 1h TTL,
+reducing average page load from 1.2s to 180ms.
+
+# With footer
+fix(sleeper): handle 429 rate limit with exponential backoff
+
+Closes #42
+
+# Full example
+feat(trade)!: change trade value response format
+
+The trade analyzer previously returned a flat score. This changes
+the response to include confidence intervals from Monte Carlo
+simulation, giving users visibility into outcome variance.
+
+BREAKING CHANGE: TradeAnalysis.score is now TradeAnalysis.expected_value.
+Clients must update to use the new field name.
+Closes #87
+```
+
+### Anti-patterns
+
+```bash
+# Vague
+fix: bug fix                         # What bug?
+
+# Past tense
+feat: added user authentication      # Use imperative: "add"
+
+# Multiple unrelated changes
+feat: add login, fix navbar, update README  # One change per commit
+
+# No context
+refactor: refactored the code        # The diff shows that. WHY?
+
+# WIP in main history
+wip: still working on this           # Squash before merge
+```
+
+---
+
+## Pull Requests
+
+### Title
+
+Follows the same convention as commit messages:
+
+```
+type(scope): imperative description
+```
+
+The squash-merge commit message will be derived from the PR title. Make it count.
+
+### Size
+
+| Size | LOC Changed | Verdict |
+|------|-------------|---------|
+| Ideal | ≤400 | Target this |
+| Acceptable | 400-800 | Justify in PR description |
+| Warning | 800-1000 | Strongly consider splitting |
+| Too large | >1000 | Split it. No exceptions. |
+
+Auto-generated files, lock files, and large deletions don't count toward LOC limits.
+
+### Description
+
+Fill out the PR template completely. The two most important sections:
+
+1. **Why** — Reviewers evaluate your *approach*, not just your code. Without context, they can only check syntax.
+2. **How to Test** — If a reviewer can't verify your change, the PR is incomplete.
+
+### Linking Issues
+
+```
+Closes #123          — auto-closes on merge (use in PR body, not commit messages)
+Related to #456      — reference without closing
+Part of #789         — partial work toward a larger goal
+```
+
+### Draft PRs
+
+Use GitHub Draft PRs for:
+- Early architectural feedback
+- WIP that's blocked on another PR
+- Sharing for async discussion
+
+Convert to Ready only when: CI green + self-review done + description complete.
+
+---
+
+## Testing
+
+### Before Opening a PR
+
+```bash
+pnpm validate          # type-check + lint + tests (MUST pass)
+```
+
+### Test Requirements
+
+| Change Type | Test Requirement |
+|-------------|-----------------|
+| Algorithm change | Unit tests required (VBD: 100% coverage) |
+| UI component | E2E test if interactive; visual check at minimum |
+| API route | Unit test for happy path + error cases |
+| Bug fix | Regression test that fails without the fix |
+| Refactor | Existing tests must still pass |
+
+### Commands
+
+```bash
+pnpm test:run          # Unit tests (Vitest)
+pnpm test:coverage     # Coverage report
+pnpm test:e2e          # E2E (Playwright: Chromium + Mobile Safari)
+pnpm type-check        # TypeScript strict mode
+pnpm lint              # ESLint
+```
+
+---
+
+## Code Standards
+
+- **TypeScript strict mode** — no `any`, no `@ts-ignore`, no `@ts-expect-error`
+- **Named exports only** — no default exports
+- **Server Components by default** — `'use client'` only when needed
+- **`motion/react`** — not framer-motion
+- **`cn()` from `@/lib/utils`** — for conditional Tailwind classes
+- **Barrel imports** — `@/lib/sleeper` not `@/lib/sleeper/client`
+
+Full conventions are in [AGENTS.md](./AGENTS.md).
+
+---
+
+## In-Code Documentation
+
+### Document these — always
+
+| What | Why |
+|------|-----|
+| Public API functions | Contract, params, return type, units |
+| Non-obvious algorithms | Why this approach, what the math means |
+| Magic numbers | `const CACHE_TTL_MS = 86_400_000 // 24h` |
+| Workarounds | `// Sleeper returns null for IR players, not 0` |
+| Complex conditions | Extract to named variable OR add comment |
+| `TODO`/`FIXME` | Always include issue reference: `// TODO(#123): ...` |
+
+### Skip documentation for
+
+- Self-evident getters/setters
+- Simple React components with clear prop names
+- Internal helpers called from a single location
+- Anything where function name + TypeScript types tell the full story
+
+### TSDoc Format
+
+```typescript
+/**
+ * Calculates Value Based Drafting score relative to a positional baseline.
+ *
+ * @param player - Player with projectedPoints in full-season fantasy points
+ * @param baseline - Replacement-level player's projected points for this position
+ * @returns Positive = above replacement, negative = below
+ *
+ * @example
+ * calculateVBD(mahomes, 280) // 142 (Mahomes projects 422pts, baseline 280)
+ */
+export function calculateVBD(player: Player, baseline: number): number {
+  return player.projectedPoints - baseline
+}
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,8 @@
-# Contributing to Quantasy
+# Quantasy — Development Reference
+
+> This is a solo-dev reference guide. The audience is future-you, not external contributors.
+> Every convention here exists to keep the project navigable, the git history readable,
+> and the knowledge base growing.
 
 ## Quick Start
 
@@ -30,6 +34,8 @@ dev  ──●──●──●──●──●──●──●──●─
 - **`dev`** — Integration branch. CI must pass before anything merges. Never commit directly.
 - **Feature branches** — All work happens here. Short-lived (1-3 days max). Branch from `dev`.
 
+**Trivial changes** (`docs:`, `chore:` single-file edits like typo fixes) may be committed directly to `dev` to reduce ceremony. Use judgment — if it touches logic, use a branch.
+
 ### Branch Naming
 
 **Pattern:** `{type}/{kebab-case-description}`
@@ -49,7 +55,6 @@ dev  ──●──●──●──●──●──●──●──●─
 - Lowercase only, kebab-case, no spaces
 - Keep under 50 characters
 - Present tense (`add-dark-mode` not `added-dark-mode`)
-- No personal names (`john/fix-bug` is meaningless to future readers)
 
 ### Branch Lifecycle
 
@@ -232,6 +237,15 @@ wip: still working on this           # Squash before merge
 
 ## Pull Requests
 
+### When to Use a PR
+
+| Change Type | PR Required? |
+|-------------|-------------|
+| `feat/`, `fix/`, `refactor/`, `perf/` | Yes — always use a branch + PR |
+| `docs:`, `chore:` (single-file, trivial) | Optional — may commit directly to `dev` |
+| Any multi-file change | Yes |
+| Anything touching logic | Yes |
+
 ### Title
 
 Follows the same convention as commit messages:
@@ -242,23 +256,17 @@ type(scope): imperative description
 
 The squash-merge commit message will be derived from the PR title. Make it count.
 
-### Size
-
-| Size | LOC Changed | Verdict |
-|------|-------------|---------|
-| Ideal | ≤400 | Target this |
-| Acceptable | 400-800 | Justify in PR description |
-| Warning | 800-1000 | Strongly consider splitting |
-| Too large | >1000 | Split it. No exceptions. |
-
-Auto-generated files, lock files, and large deletions don't count toward LOC limits.
-
 ### Description
 
-Fill out the PR template completely. The two most important sections:
+The PR template has three sections. The only hard requirement is **Why**.
 
-1. **Why** — Reviewers evaluate your *approach*, not just your code. Without context, they can only check syntax.
-2. **How to Test** — If a reviewer can't verify your change, the PR is incomplete.
+1. **Why** — The motivation. Future-you WILL forget why you made this change in 3 months. Write it down now.
+2. **What Changed** — Brief narrative of the approach and key decisions. Not a diff recap — explain the thinking.
+3. **Learnings** — Knowledge captured during the work. See [Learnings Feedback Loop](#learnings-feedback-loop) below.
+
+### One Logical Change Per PR
+
+Keep each PR focused on a single logical change. This isn't about LOC limits — it's about keeping the git history navigable. If you're mixing a feature with a refactor, split them.
 
 ### Linking Issues
 
@@ -268,20 +276,41 @@ Related to #456      — reference without closing
 Part of #789         — partial work toward a larger goal
 ```
 
-### Draft PRs
+---
 
-Use GitHub Draft PRs for:
-- Early architectural feedback
-- WIP that's blocked on another PR
-- Sharing for async discussion
+## Learnings Feedback Loop
 
-Convert to Ready only when: CI green + self-review done + description complete.
+Every PR has a **Learnings** section. This is the knowledge capture mechanism that keeps the project improving.
+
+### What to Capture
+
+| Category | Example |
+|----------|---------|
+| **Gotchas** | "Sleeper API returns `null` for IR players, not `0` — broke the VBD baseline" |
+| **Stuck points** | "Spent 2h debugging a hydration mismatch — turned out `useEffect` was running before auth context resolved" |
+| **Decisions** | "Chose SHA256 over MD5 for cache keys because Node's crypto module is equally fast for both" |
+| **Patterns discovered** | "The `await params` pattern in Next.js 15+ applies to all dynamic route segments, not just `[id]`" |
+| **Gaps found** | "AGENTS.md doesn't mention the `getCurrentSeason()` util — should be added to WHERE TO LOOK" |
+
+### How Learnings Feed Back
+
+After merging a PR, review the Learnings section and determine where the knowledge should live permanently:
+
+| If the learning is... | Then update... |
+|-----------------------|----------------|
+| A new rule or constraint | `AGENTS.md` → CONVENTIONS or ANTI-PATTERNS |
+| A gotcha about an API or library | `AGENTS.md` → relevant section, or module's own AGENTS.md |
+| A reusable pattern for AI agents | A skill file or orchestration config |
+| A workaround for a specific tool | Inline code comment with `// GOTCHA:` prefix |
+| An architectural decision worth remembering | `AGENTS.md` → ARCHITECTURE PATTERNS or a dedicated ADR if significant |
+
+This loop is what turns individual PRs into institutional knowledge. Don't skip it.
 
 ---
 
 ## Testing
 
-### Before Opening a PR
+### Before Merging
 
 ```bash
 pnpm validate          # type-check + lint + tests (MUST pass)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Scope is optional. Omit when the change is cross-cutting or doesn't fit a single
 ### Footer Conventions
 
 ```
-Closes #123              — auto-closes issue on merge
+Closes #123              — auto-closes issue on merge (use in PR body)
 Fixes #456               — same as Closes
 Refs #789                — reference without closing
 BREAKING CHANGE: <desc>  — triggers MAJOR version bump
@@ -271,10 +271,12 @@ Keep each PR focused on a single logical change. This isn't about LOC limits —
 ### Linking Issues
 
 ```
-Closes #123          — auto-closes on merge (use in PR body, not commit messages)
+Closes #123          — auto-closes on merge
 Related to #456      — reference without closing
 Part of #789         — partial work toward a larger goal
 ```
+
+Use `Closes`/`Fixes` in the **PR body** — GitHub reads these on merge. Avoid putting them in commit messages (noise when cherry-picked).
 
 ---
 
@@ -340,8 +342,8 @@ pnpm lint              # ESLint
 
 ## Code Standards
 
-- **TypeScript strict mode** — no `any`, no `@ts-ignore`, no `@ts-expect-error`
-- **Named exports only** — no default exports
+- **TypeScript strict mode** — no `any`, no `@ts-ignore`, no `@ts-expect-error` in production code (tests may use `any` for mocking per ESLint config)
+- **Named exports** for libraries and components — default exports only where framework-required (Next.js route files: `page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`)
 - **Server Components by default** — `'use client'` only when needed
 - **`motion/react`** — not framer-motion
 - **`cn()` from `@/lib/utils`** — for conditional Tailwind classes


### PR DESCRIPTION
## Why

Quantasy had no formal conventions for branching, commits, PRs, or documentation. Changes went directly to `prod` with inconsistent messages (`init`, `init plan`). Needed industry-standard practices adapted for a solo-dev workflow — conventions for helping future-me out to both rememeber what/why and capture useful knowledge.

## What Changed

Established a complete Git workflow based on Conventional Commits, Keep a Changelog, and Modified GitHub Flow, then adapted everything for solo-dev reality:

- **CONTRIBUTING.md** — Reframed as a solo-dev reference guide (not an external contributor onboarding doc). Covers branching, commits, PRs, testing, code standards, TSDoc, and the learnings feedback loop.
- **PR template** — Simplified from 64 lines of team-review boilerplate to a lean Why/What Changed/Learnings format with a single CI checkbox. The Learnings section is my main contribution — it captures gotchas, decisions, and gaps that feed back into AGENTS.md and skills.
- **CHANGELOG.md** — Keep a Changelog v1.1.0 format with `[Unreleased]` accumulation and a v0.1.0 entry covering all existing features.
- **AGENTS.md** — Added GIT WORKFLOW section with branching, commits, PRs, learnings loop, and merge strategy. Allows trivial `docs:`/`chore:` changes directly to `dev`.

## Learnings

- **PR templates designed for teams don't work solo.** Direct value is to capturing *why* you made a change and *what you learned* — not convincing someone else your code is correct.
- **The learnings feedback loop is the is going to ***HOPEFULLY*** pay future dividends. ** Without it, knowledge dies in the PR description. With it, every PR becomes a candidate for AGENTS.md rules, new skills, or code comments. This is how the project's knowledge base grows organically.
- **LOC-gated PR size limits are a team concern.** The research (SmartBear, Google) all frames size limits in terms of reviewer fatigue. For solo dev, the right constraint is "one logical change per PR" — which is about git history readability, not review burden.
- **Trivial changes should be trivial to commit/push** Requiring a full branch + PR for a one-line typo fix in a README creates friction that could discourage documentation. Direct push to `dev` for `docs:` and `chore:` single-file changes is fine assuming I don't go crazy with the power.

---

- [x] CI passes (`pnpm validate`)